### PR TITLE
Fix initialization of CFLAGS_INIT

### DIFF
--- a/config.zdnn
+++ b/config.zdnn
@@ -26,7 +26,7 @@ case "${target}" in
 	LD=${LD:-g++}
 	AR=${AR:-ar}
 	ARFLAGS="${ARFLAGS:--rc}"
-	CFLAGS_INIT="-O3 -mzvector -Wall -std=gnu99 -fstack-protector-all ${CFLAGS:-}"
+	CFLAGS_INIT="-O3 -mzvector -Wall -std=gnu99 -fstack-protector-all ${CFLAGS_INIT:-}"
 	CFLAGS_QUOTE_INIT="-Wall" # Not needed on Linux. Just repeat an option to prevent it from being empty.
 	CFLAGS="-O3 -march=z14 -mzvector -Wall -std=gnu99 -fstack-protector-all ${CFLAGS:-}"
 	CFLAGS_QUOTE="-Wall"
@@ -57,7 +57,7 @@ case "${target}" in
 	AR=${AR:-ar}
 	ARFLAGS="${ARFLAGS:--rc}"
 	CXXFLAGS="-I /u/mvsbuild/zos25/usr/include/zos/ -Wc,ASM,LP64,INLINE,VECTOR ${CXXFLAGS:-}"
-	CFLAGS_INIT="${CXXFLAGS} -qlanglvl=extc99 ${CFLAGS:-}"
+	CFLAGS_INIT="${CXXFLAGS} -qlanglvl=extc99 ${CFLAGS_INIT:-}"
 	CFLAGS_QUOTE_INIT="-Wc,SUPPRESS(CCN4108),STACKPROTECT(ALL)" # The options with () require an extra pair of quotes in config.make.in
 	CFLAGS="${CXXFLAGS} -qlanglvl=extc99 ${CFLAGS:-}"
 	CFLAGS_QUOTE="-Wc,ARCH(12),SUPPRESS(CCN4108),STACKPROTECT(ALL)"


### PR DESCRIPTION
Fix a typo which currently prevents us from overriding CFLAGS_INIT from outside as it is required for package building.

Signed-off-by: Andreas Krebbel <krebbel@linux.ibm.com>