### PR TITLE
Limit symbol check to global symbols

### DIFF
--- a/zdnn/sym_checker.awk
+++ b/zdnn/sym_checker.awk
@@ -283,7 +283,7 @@ fi == fi_dyn && NF >= 8 {
 	else
 	    dbg(1, "Skipping UND symbol: "dyn_name)
 	next
-    } else if ($7 ~ /[0-9]+/) {
+    } else if ($5 == "GLOBAL" && $7 ~ /[0-9]+/) {
 	# 'zdnn_sub@@ZDNN_1.0' => 'zdnn_sub' and return > 0 if "@" was found
 	dyn_sym=dyn_name
 	if (sub("@.*", "", dyn_sym) == 0) {


### PR DESCRIPTION
This adjusts the sym_checker.awk script to only check symbols with GLOBAL binding. 

With recent Binutils we get a line for the local .init section symbol in the readelf output. In its current version the symbol checker is complaining about the presence of that symbol:
1: 0000000000002500     0 SECTION LOCAL  DEFAULT   10 .init

Signed-off-by: Andreas Krebbel <krebbel@linux.ibm.com>