### PR TITLE
Fix Makefile dependencies

### DIFF
--- a/zdnn/Makefile
+++ b/zdnn/Makefile
@@ -57,7 +57,7 @@ $(SODIR)/$(LIBNAME).so: $(INIT_OBJFILE) $(OBJFILES) $(H_FILES)
 clean:
 	$(RM) $(OBJDIR)/*.o $(OBJDIR)/*.lst $(OBJDIR)/*.d *~ core $(SODIR)/* \
 	*.so* ../zdnn/zdnn_private.map \
-	zdnn_preprocessed.h zdnn.dynsyms
+	zdnn.i zdnn.dynsyms symcheck
 
 .PHONY: install
 

--- a/zdnn/sym_checker.awk
+++ b/zdnn/sym_checker.awk
@@ -19,7 +19,7 @@
 #
 # Usage:
 # awk [ -v debug=<DBG> ] -f <ZDNN_H_PREPROCESSED> <ZDNN_MAP> <ZDNN_DYNSYMS>
-# <ZDNN_H_PREPROCESSED>: gcc -E -c <src>/zdnn/zdnn.h -o zdnn_preprocessed.h
+# <ZDNN_H_PREPROCESSED>: gcc -E <src>/zdnn/zdnn.h -o zdnn.i
 # <ZDNN_MAP>: <src>/zdnn/zdnn.map
 # <ZDNN_DYNSYMS>: readelf -W --dyn-syms libzdnn.so
 # <DBG>: To get debug-output, run with debug > 0
@@ -128,11 +128,11 @@ fi == fi_hdr && /^#/ {
     # # 23 "../zdnn/zdnn.h" 2
     hdr_basename=$3
 
-    # '"/PATH/TO/zdnn.h"' => 'zdnn.h"'
-    sub(".*/", "", hdr_basename)
+    # Strip all double quotes
+    gsub("\"", "", hdr_basename)
 
-    # 'zdnn.h"' => 'zdnn.h'
-    sub("\"$", "", hdr_basename)
+    # '/PATH/TO/zdnn.h' => 'zdnn.h'
+    sub(".*/", "", hdr_basename)
 
     if (hdr_basename == "zdnn.h")
 	hdr_in_zdnn_h=1

--- a/zdnn/t-libsoname
+++ b/zdnn/t-libsoname
@@ -18,10 +18,14 @@
 # API levels to co-exist in the system.
 # This is only supported on Linux right now.
 
+$(SODIR)/$(LIBSONAME): $(SODIR)/$(LIBNAME).so
+	ln -f -s $(LIBNAME).so $@
+
+$(SODIR)/$(LIBSONAME_PRIVATE): $(SODIR)/$(LIBNAME_PRIVATE).so
+	ln -f -s $(LIBNAME_PRIVATE).so $@
+
 .PHONY: libsoname
-libsoname:
-	ln -f -s $(LIBNAME).so $(SODIR)/$(LIBSONAME)
-	ln -f -s $(LIBNAME_PRIVATE).so $(SODIR)/$(LIBSONAME_PRIVATE)
+libsoname: $(SODIR)/$(LIBSONAME) $(SODIR)/$(LIBSONAME_PRIVATE)
 
 .PHONY: install_libsoname
 install_libsoname: install_shared

--- a/zdnn/t-symcheck
+++ b/zdnn/t-symcheck
@@ -22,10 +22,12 @@
 # useful on z/OS to get notified when things are getting out of sync
 # between Linux and z/OS.
 
-.PHONY: symcheck
-symcheck: $(SODIR)/$(LIBNAME).so
+zdnn.i: zdnn.h
+	$(CC) -E $< -o $@
+
+symcheck: $(SODIR)/$(LIBNAME).so zdnn.i
 ifneq ($(READELF),)
-	$(CC) -E -c ../zdnn/zdnn.h -o zdnn_preprocessed.h
 	$(READELF) -W --dyn-syms $(SODIR)/$(LIBNAME).so > zdnn.dynsyms
-	awk -f sym_checker.awk zdnn_preprocessed.h ../zdnn/zdnn.map zdnn.dynsyms
+	awk -f sym_checker.awk zdnn.i zdnn.map zdnn.dynsyms >symcheck
+	cat symcheck
 endif


### PR DESCRIPTION
Running make several times still relinks libzdnn and does perform the
symbol checking even if nothing changed.  This is the result of not
having all dependencies written out explicitely in the Makefile.

In order to fix this I had to:

- Add a file target for the symbol check 'symcheck'.

- Rename zdnn_preprocessed.h to zdnn.i to prevent it from being picked
  up by the *.h wildcard in the zdnn Makefile.

- Add an explicit rule for the creation of zdnn.i.

- Change sym_checker.awk so that it is able to deal with just "zdnn.h"
  instead of "../zdnn/zdnn.h". Right now the leading " is only
  stripped if there is also a / in the file path.

- Put the symlink creation for the sonames into explicit rules.

Signed-off-by: Andreas Krebbel <krebbel@linux.ibm.com>