### PR TITLE
add: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: File a bug/issue
+title: '[BUG] <title>'
+labels: Bug, Needs Triage
+assignees: ''
+
+---
+
+<!--
+Note: Please use the search to see if a similar issue already exists.
+-->
+
+### Current Observation:
+<!-- what kind of issue did you discover? -->
+
+### Expected:
+<!-- A concise description of what you expected to see. -->
+
+### Location:
+<!-- Provide some details to the location. -->
+
+### Anything else:
+<!--
+Links? References? Anything that will give more context about the issue!
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution or source you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Templates to unify issues and descriptions with focus on traceability.

Signed-off-by: Jan Polensky <jan.polensky@ibm.com>